### PR TITLE
Added the possibility to chose when to run T4 templates (before build, after build, not at all)

### DIFF
--- a/AutoT4/AutoT4.csproj
+++ b/AutoT4/AutoT4.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Guids.cs" />
     <Compile Include="AutoT4ExtenderProvider.cs" />
     <Compile Include="AutoT4Extender.cs" />
+    <Compile Include="ExtensionMethods.cs" />
     <Compile Include="ProjectItemSettings.cs" />
     <Compile Include="Resources.Designer.cs">
       <AutoGen>True</AutoGen>

--- a/AutoT4/AutoT4ProjectItemSettings.cs
+++ b/AutoT4/AutoT4ProjectItemSettings.cs
@@ -11,16 +11,23 @@ namespace BennorMcCarthy.AutoT4
     public class AutoT4ProjectItemSettings : ProjectItemSettings
     {
         public AutoT4ProjectItemSettings(ProjectItem item)
-            : base(item, "AutoT4") {}
+            : base(item, "AutoT4") { }
 
-        [DefaultValue(true)]
+        [DefaultValue(BuildEvent.BeforeBuild)]
         [DisplayName("Run on build")]
         [Category("AutoT4")]
         [Description("Whether to run this template at build time or not.")]
-        public bool RunOnBuild
+        public BuildEvent RunOnBuild
         {
-            get { return Get(true); }
+            get { return Get(BuildEvent.BeforeBuild); }
             set { Set(value); }
         }
+    }
+
+    public enum BuildEvent
+    {
+        DoNotRun,
+        BeforeBuild,
+        AfterBuild
     }
 }

--- a/AutoT4/AutoT4ProjectItemSettings.cs
+++ b/AutoT4/AutoT4ProjectItemSettings.cs
@@ -10,17 +10,35 @@ namespace BennorMcCarthy.AutoT4
     [ClassInterface(ClassInterfaceType.None)]
     public class AutoT4ProjectItemSettings : ProjectItemSettings
     {
+        private const BuildEvent DefaultRunOnBuildSetting = BuildEvent.BeforeBuild;
+
         public AutoT4ProjectItemSettings(ProjectItem item)
             : base(item, "AutoT4") { }
 
-        [DefaultValue(BuildEvent.BeforeBuild)]
+        [DefaultValue(DefaultRunOnBuildSetting)]
         [DisplayName("Run on build")]
         [Category("AutoT4")]
         [Description("Whether to run this template at build time or not.")]
         public BuildEvent RunOnBuild
         {
-            get { return Get(BuildEvent.BeforeBuild); }
+            get { return Get(DefaultRunOnBuildSetting, CoerceOldRunOnBuildValue); }
             set { Set(value); }
+        }
+
+        /// <summary>
+        /// Converts the old <see cref="bool"/> <see cref="RunOnBuild"/> property to <see cref="BuildEvent"/>
+        /// </summary>
+        private BuildEvent CoerceOldRunOnBuildValue(string value)
+        {
+            var newRunOnBuildValue = DefaultRunOnBuildSetting;
+            bool previousRunOnBuild;
+            if (bool.TryParse(value, out previousRunOnBuild))
+                newRunOnBuildValue = previousRunOnBuild ? BuildEvent.BeforeBuild : BuildEvent.DoNotRun;
+
+            //coercion was needed, therefore the new value needs to be assigned so that it gets migrated in the settings
+            RunOnBuild = newRunOnBuildValue;
+
+            return newRunOnBuildValue;
         }
     }
 

--- a/AutoT4/ExtensionMethods.cs
+++ b/AutoT4/ExtensionMethods.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using EnvDTE;
+using VSLangProj;
+
+namespace BennorMcCarthy.AutoT4
+{
+    public static class DTEExtensions
+    {
+        public static IEnumerable<Project> GetProjectsWithinBuildScope(this DTE dte, vsBuildScope scope)
+        {
+            IEnumerable<Project> projects = null;
+
+            switch (scope)
+            {
+                case vsBuildScope.vsBuildScopeSolution:
+                    projects = dte.Solution.Projects.OfType<Project>();
+                    break;
+                case vsBuildScope.vsBuildScopeProject:
+                    projects = ((object[])dte.ActiveSolutionProjects).OfType<Project>();
+                    break;
+            }
+
+            return projects ?? Enumerable.Empty<Project>();
+        }
+    }
+
+    public static class ProjectItemExtensions
+    {
+        public static IEnumerable<ProjectItem> ThatShouldRunOn(this IEnumerable<ProjectItem> projectItems, BuildEvent whenToRun)
+        {
+            return projectItems.Where(projectItem => projectItem.ShouldRunOn(whenToRun));
+        }
+
+        public static bool ShouldRunOn(this ProjectItem projectItem, BuildEvent whenToRun)
+        {
+            return (new AutoT4ProjectItemSettings(projectItem)).RunOnBuild == whenToRun;
+        }
+
+        public static void RunTemplate(this ProjectItem template)
+        {
+            var templateVsProjectItem = template.Object as VSProjectItem;
+            if (templateVsProjectItem != null)
+            {
+                templateVsProjectItem.RunCustomTool();
+            }
+            else
+            {
+                if (!template.IsOpen)
+                    template.Open();
+                template.Save();
+            }
+        }
+    }
+
+    public static class ProjectExtensions
+    {
+        public static IEnumerable<ProjectItem> FindT4ProjectItems(this IEnumerable<Project> projects)
+        {
+            return FindProjectItems(@"\.[Tt][Tt]$", projects);
+        }
+
+        private static IEnumerable<ProjectItem> FindProjectItems(string pattern, IEnumerable<Project> projects)
+        {
+            var regex = new Regex(pattern);
+            foreach (Project project in projects)
+            {
+                foreach (var projectItem in FindProjectItems(regex, project.ProjectItems))
+                    yield return projectItem;
+            }
+        }
+
+        private static IEnumerable<ProjectItem> FindProjectItems(Regex regex, ProjectItems projectItems)
+        {
+            foreach (ProjectItem projectItem in projectItems)
+            {
+                if (regex.IsMatch(projectItem.Name ?? ""))
+                    yield return projectItem;
+
+                if (projectItem.ProjectItems != null)
+                {
+                    foreach (var subItem in FindProjectItems(regex, projectItem.ProjectItems))
+                        yield return subItem;
+                }
+                if (projectItem.SubProject != null)
+                {
+                    foreach (var subItem in FindProjectItems(regex, projectItem.SubProject.ProjectItems))
+                        yield return subItem;
+                }
+            }
+        }
+    }
+}

--- a/AutoT4/ProjectItemSettings.cs
+++ b/AutoT4/ProjectItemSettings.cs
@@ -22,10 +22,10 @@ namespace BennorMcCarthy.AutoT4
             if (item == null)
                 throw new ArgumentNullException("item");
 
-            if(!string.IsNullOrWhiteSpace(scope))
+            if (!string.IsNullOrWhiteSpace(scope))
                 _scope = scope.Trim();
 
-            var solution = (IVsSolution) Package.GetGlobalService(typeof (SVsSolution));
+            var solution = (IVsSolution)Package.GetGlobalService(typeof(SVsSolution));
 
             IVsHierarchy hierarchy;
             if (0 != solution.GetProjectOfUniqueName(item.ContainingProject.UniqueName, out hierarchy))
@@ -36,7 +36,7 @@ namespace BennorMcCarthy.AutoT4
                 return;
 
             var fullPath = item.FileNames[0];
-                
+
             if (0 != hierarchy.ParseCanonicalName(fullPath, out _itemId))
                 return;
 
@@ -67,9 +67,21 @@ namespace BennorMcCarthy.AutoT4
             if (0 != _storage.GetItemAttribute(_itemId, Scope(name), out serializedValue))
                 return defaultValue;
 
-            return !String.IsNullOrWhiteSpace(serializedValue)
-                       ? (T)Convert.ChangeType(serializedValue, typeof(T))
-                       : defaultValue;
+            if (string.IsNullOrWhiteSpace(serializedValue))
+                return defaultValue;
+            
+            try
+            {
+                if (typeof (T).IsEnum)
+                {
+                    return (T) Enum.Parse(typeof (T), serializedValue);
+                }
+                return (T) Convert.ChangeType(serializedValue, typeof (T));
+            }
+            catch
+            {
+                return defaultValue;
+            }
         }
 
         private string Scope(string name)

--- a/AutoT4/ProjectItemSettings.cs
+++ b/AutoT4/ProjectItemSettings.cs
@@ -55,7 +55,7 @@ namespace BennorMcCarthy.AutoT4
             _storage.SetItemAttribute(_itemId, Scope(name), serializedValue);
         }
 
-        protected T Get<T>(T defaultValue = default(T), [CallerMemberName] string name = null)
+        protected T Get<T>(T defaultValue = default(T), Func<string, T> coercionFunc = null, [CallerMemberName] string name = null)
         {
             if (name == null)
                 throw new ArgumentNullException("name");
@@ -69,17 +69,20 @@ namespace BennorMcCarthy.AutoT4
 
             if (string.IsNullOrWhiteSpace(serializedValue))
                 return defaultValue;
-            
+
             try
             {
-                if (typeof (T).IsEnum)
+                if (typeof(T).IsEnum)
                 {
-                    return (T) Enum.Parse(typeof (T), serializedValue);
+                    return (T)Enum.Parse(typeof(T), serializedValue);
                 }
-                return (T) Convert.ChangeType(serializedValue, typeof (T));
+                return (T)Convert.ChangeType(serializedValue, typeof(T));
             }
             catch
             {
+                if (coercionFunc != null)
+                    return coercionFunc(serializedValue);
+
                 return defaultValue;
             }
         }


### PR DESCRIPTION
Hi, 
In my case I need to run the T4 templates after the build finishes, therefore I implemented it.

Except the actual functionality, there are also some changes in the coding style, if they don't appeal to you, I wont mind if you don't take them in :)

Here's the list of changes implemented here:
 - Moved all the methods that deal with finding the template files and running them into extension methods, so that the AutoT4Package.cs file is more concise and easy to parse for a newcomer;
 - **[important]** In AutoT4ProjectItemSettings the RunOnBuild is now of type BuildEvent, so that users can chose when they want to run the templates. However, the code does not migrate the previous value (this means that current users updating the extension will lose their previous setting);
 - In ProjectItemSettings I wrapped the conversion in a try/catch block;

Please let me know if you intend to accept this.

Have a great day!
Cosmin