### PR TITLE
Close template window if it wasn't open before the run

### DIFF
--- a/AutoT4/ExtensionMethods.cs
+++ b/AutoT4/ExtensionMethods.cs
@@ -49,8 +49,10 @@ namespace BennorMcCarthy.AutoT4
             }
             else
             {
-                if (template.IsOpen) template.Save();
-                else template.Open().Close(vsSaveChanges.vsSaveChangesYes);
+                if (template.IsOpen)
+                    template.Save();
+                else
+                    template.Open().Close(vsSaveChanges.vsSaveChangesYes);
             }
         }
     }

--- a/AutoT4/ExtensionMethods.cs
+++ b/AutoT4/ExtensionMethods.cs
@@ -49,9 +49,8 @@ namespace BennorMcCarthy.AutoT4
             }
             else
             {
-                if (!template.IsOpen)
-                    template.Open();
-                template.Save();
+                if (template.IsOpen) template.Save();
+                else template.Open().Close(vsSaveChanges.vsSaveChangesYes);
             }
         }
     }

--- a/AutoT4/ExtensionMethods.cs
+++ b/AutoT4/ExtensionMethods.cs
@@ -49,10 +49,16 @@ namespace BennorMcCarthy.AutoT4
             }
             else
             {
-                if (template.IsOpen)
+                if (!template.IsOpen)
+                {
+                    var window = template.Open();
                     template.Save();
+                    window.Close();
+                }
                 else
-                    template.Open().Close(vsSaveChanges.vsSaveChangesYes);
+                {
+                    template.Save();
+                }
             }
         }
     }


### PR DESCRIPTION
This solves the annoyance of having all .tt files open after each build. Template files that were previously closed will get closed again in the editor.